### PR TITLE
iPhone x

### DIFF
--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -367,14 +367,12 @@
             break;
             
         case 5:
-            modal = YES;
+//            modal = YES;
             viewController = [SettingsViewController controllerWithNib];
 
-            [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
-            
-            // use the saved index path to re-select the previous index since settings selection should not persist as a modal
-            if (![[LatestChatty2AppDelegate delegate] isPadDevice]) {
-                [self.tableView selectRowAtIndexPath:self.selectedIndex animated:YES scrollPosition:UITableViewScrollPositionNone];
+            if ([[LatestChatty2AppDelegate delegate] isPadDevice]) {
+                [appDelegate.contentNavigationController setViewControllers:[NSArray arrayWithObject:viewController]];
+                viewController = nil;
             }
             
             break;

--- a/Classes/SettingsViewController.m
+++ b/Classes/SettingsViewController.m
@@ -177,9 +177,6 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
     // available browser types vary based on availability of apps & iOS version
     browserTypes = [[NSMutableArray alloc] init];
     browserTypesValues = [[NSMutableArray alloc] init];
-    // everyone gets web view
-    [browserTypes addObject:@"Web View"];
-    [browserTypesValues addObject:[NSNumber numberWithInteger:LCBrowserTypeWebView]];
     // only iOS 9+ can use safari view
     if ([self canOpenSafariView]) {
         [browserTypes addObject:@"Safari View"];

--- a/Classes/SettingsViewController.m
+++ b/Classes/SettingsViewController.m
@@ -91,6 +91,18 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    if (![[LatestChatty2AppDelegate delegate] isPadDevice]) {
+        UIBarButtonItem *menuButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"Menu-Button-List.png"]
+                                                                       style:UIBarButtonItemStylePlain
+                                                                      target:self.viewDeckController
+                                                                      action:@selector(toggleLeftView)];
+        self.navigationItem.leftBarButtonItem = menuButton;
+    }
+    
+    UIBarButtonItem *saveButton = [[UIBarButtonItem alloc] initWithTitle:@"Save" style:UIBarButtonItemStyleDone target:self action:@selector(dismiss:)];
+    self.navigationItem.rightBarButtonItem = saveButton;
+    
+    
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *shackUserName = [defaults valueForKey:@"username"];
     BOOL pushEnabled = [defaults boolForKey:@"pushMessages"];
@@ -456,7 +468,7 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
 - (IBAction)dismiss:(id)sender {
     [self saveSettings];
 	
-    [self dismissViewControllerAnimated:YES completion:nil];
+    [self.viewDeckController toggleLeftView];
 }
 
 - (void)openCredits {

--- a/Classes/SettingsViewController.xib
+++ b/Classes/SettingsViewController.xib
@@ -1,14 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SettingsViewController">
             <connections>
-                <outlet property="cancelButton" destination="5u2-se-1ox" id="z2N-2y-qtp"/>
-                <outlet property="saveButton" destination="64" id="66"/>
                 <outlet property="tableView" destination="57" id="60"/>
                 <outlet property="view" destination="1" id="4"/>
             </connections>
@@ -18,42 +20,17 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="grouped" showsSelectionImmediatelyOnTouchBegin="NO" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" id="57">
-                    <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" bouncesZoom="NO" style="grouped" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" id="57">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <animations/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="58"/>
                         <outlet property="delegate" destination="-1" id="59"/>
                     </connections>
                 </tableView>
-                <navigationBar contentMode="scaleToFill" translucent="NO" id="62">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <animations/>
-                    <color key="barTintColor" red="0.11372549019607843" green="0.11372549019607843" blue="0.12549019607843137" alpha="1" colorSpace="calibratedRGB"/>
-                    <textAttributes key="titleTextAttributes">
-                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    </textAttributes>
-                    <items>
-                        <navigationItem title="Settings" id="63">
-                            <barButtonItem key="leftBarButtonItem" style="done" systemItem="cancel" id="5u2-se-1ox">
-                                <connections>
-                                    <action selector="cancel:" destination="-1" id="BCh-2r-fNQ"/>
-                                </connections>
-                            </barButtonItem>
-                            <barButtonItem key="rightBarButtonItem" title="Save" style="done" id="64">
-                                <connections>
-                                    <action selector="dismiss:" destination="-1" id="65"/>
-                                </connections>
-                            </barButtonItem>
-                        </navigationItem>
-                    </items>
-                </navigationBar>
             </subviews>
-            <animations/>
-            <color key="backgroundColor" red="0.12549019607843137" green="0.12549019607843137" blue="0.14117647058823529" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.12549019607843137" green="0.12549019607843137" blue="0.14117647058823529" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </view>

--- a/Classes/ThreadViewController.m
+++ b/Classes/ThreadViewController.m
@@ -567,17 +567,7 @@
                 [[UIApplication sharedApplication] openURL:[request URL]];
                 return NO;
             }
-            // open current URL in iOS 9 Safari modal view
-            if (browserPref == LCBrowserTypeSafariView) {
-                [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
-                
-                SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:[request URL]];
-                [svc setDelegate:self];
-                
-                [[self showingViewController] presentViewController:svc animated:YES completion:nil];
-                
-                return NO;
-            }
+            
             // open current URL in Chrome app
             if (browserPref == LCBrowserTypeChromeApp) {
                 // replace http,https:// with googlechrome://
@@ -589,13 +579,15 @@
                     return NO;
                 }
             }
-
-            viewController = [[BrowserViewController alloc] initWithRequest:request];
+            
+            // open current URL in iOS 9 Safari modal view.
+            // Fall back to LCBrowserTypeSafariView as the default.
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
+            SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:[request URL]];
+            [svc setDelegate:self];
+            [[self showingViewController] presentViewController:svc animated:YES completion:nil];
+            return NO;
         }
-        
-        [self.navigationController pushViewController:viewController animated:YES];
-        
-        return NO;
     }
     
     return YES;

--- a/Classes/iPad/SettingsViewController-iPad.xib
+++ b/Classes/iPad/SettingsViewController-iPad.xib
@@ -1,14 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" colorMatched="YES">
+    <device id="ipad9_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SettingsViewController">
             <connections>
-                <outlet property="cancelButton" destination="lq0-zA-JNK" id="nIR-d9-vq6"/>
-                <outlet property="saveButton" destination="7" id="61"/>
                 <outlet property="tableView" destination="57" id="60"/>
                 <outlet property="view" destination="1" id="4"/>
             </connections>
@@ -18,42 +20,17 @@
             <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <navigationBar contentMode="scaleToFill" translucent="NO" id="5">
-                    <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <animations/>
-                    <color key="barTintColor" red="0.1137254902" green="0.1137254902" blue="0.12549019610000001" alpha="1" colorSpace="calibratedRGB"/>
-                    <textAttributes key="titleTextAttributes">
-                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    </textAttributes>
-                    <items>
-                        <navigationItem title="Settings" id="6">
-                            <barButtonItem key="leftBarButtonItem" style="done" systemItem="cancel" id="lq0-zA-JNK">
-                                <connections>
-                                    <action selector="cancel:" destination="-1" id="qk6-mD-qJr"/>
-                                </connections>
-                            </barButtonItem>
-                            <barButtonItem key="rightBarButtonItem" style="done" systemItem="save" id="7">
-                                <connections>
-                                    <action selector="dismiss:" destination="-1" id="13"/>
-                                </connections>
-                            </barButtonItem>
-                        </navigationItem>
-                    </items>
-                </navigationBar>
-                <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="grouped" showsSelectionImmediatelyOnTouchBegin="NO" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="57">
-                    <rect key="frame" x="0.0" y="44" width="768" height="980"/>
+                <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" bouncesZoom="NO" style="grouped" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="57">
+                    <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <animations/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="58"/>
                         <outlet property="delegate" destination="-1" id="59"/>
                     </connections>
                 </tableView>
             </subviews>
-            <animations/>
-            <color key="backgroundColor" red="0.12549019610000001" green="0.12549019610000001" blue="0.14117647059999999" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.12549019610000001" green="0.12549019610000001" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
         </view>
     </objects>


### PR DESCRIPTION
Proper support for the iPhone X.

![iphonex](https://d26dzxoao6i3hh.cloudfront.net/items/462P3w1I453w112b2W07/Image%202017-11-08%20at%2010.46.25%20PM.png)

I changed two things:

* The settings page had it's header buried in the notch. I made it a normal view controller like all the other, and not a modal anymore. When you tap save, it shows the left menu letting you know you move to a different screen. iPad functionality should be unchanged.
* Deprecated the WebView link viewing option, which was rendering it's browser controls over the home gesture area. People should be on iOS 9 by now and have access to the SafariView which is far superior anyway. I removed the entry from the settings page, removed handling the WebView preference, and let SafariView be the default.